### PR TITLE
fix training compiling fail in cuda lower than 11

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,3 @@ global-include *.txt
 global-include *.cu *.cpp *.cc *.cuh *.h *.ldscript *.proto *.cmake
 prune dist
 prune build
-graft 3rdparty

--- a/lightseq/training/ops/pytorch/builder/kernel_builder.py
+++ b/lightseq/training/ops/pytorch/builder/kernel_builder.py
@@ -3,6 +3,7 @@
 # This builder is adapted from Microsoft DeepSpeed
 
 import torch
+import pathlib
 from .builder import CUDAOpBuilder
 
 
@@ -29,7 +30,11 @@ class KernelBuilder(CUDAOpBuilder):
         ]
 
     def include_paths(self):
-        return ["csrc/kernels/includes", "csrc/ops/includes"]
+        return [
+            "csrc/kernels/includes",
+            "csrc/ops/includes",
+            str(pathlib.Path(__file__).parents[5] / "3rdparty" / "cub"),
+        ]
 
     def nvcc_args(self):
         args = [

--- a/lightseq/training/ops/pytorch/builder/kernel_builder.py
+++ b/lightseq/training/ops/pytorch/builder/kernel_builder.py
@@ -44,6 +44,7 @@ class KernelBuilder(CUDAOpBuilder):
             "-U__CUDA_NO_HALF_OPERATORS__",
             "-U__CUDA_NO_HALF_CONVERSIONS__",
             "-U__CUDA_NO_HALF2_OPERATORS__",
+            "-DTHRUST_IGNORE_CUB_VERSION_CHECK",
         ]
 
         return args + self.compute_capability_args()

--- a/lightseq/training/ops/pytorch/builder/transformer_builder.py
+++ b/lightseq/training/ops/pytorch/builder/transformer_builder.py
@@ -3,6 +3,7 @@
 # This file is adapted from Microsoft DeepSpeed
 
 import torch
+import pathlib
 from .builder import CUDAOpBuilder
 
 
@@ -35,7 +36,11 @@ class TransformerBuilder(CUDAOpBuilder):
         ]
 
     def include_paths(self):
-        return ["csrc/kernels/includes", "csrc/ops/includes"]
+        return [
+            "csrc/kernels/includes",
+            "csrc/ops/includes",
+            str(pathlib.Path(__file__).parents[5] / "3rdparty" / "cub"),
+        ]
 
     def nvcc_args(self):
         args = [

--- a/lightseq/training/ops/pytorch/builder/transformer_builder.py
+++ b/lightseq/training/ops/pytorch/builder/transformer_builder.py
@@ -50,6 +50,7 @@ class TransformerBuilder(CUDAOpBuilder):
             "-U__CUDA_NO_HALF_OPERATORS__",
             "-U__CUDA_NO_HALF_CONVERSIONS__",
             "-U__CUDA_NO_HALF2_OPERATORS__",
+            "-DTHRUST_IGNORE_CUB_VERSION_CHECK",
         ]
 
         return args + self.compute_capability_args()

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ with open("README.md", "r") as fh:
 
 setup_kwargs = dict(
     name="lightseq",
-    version="2.0.2",
+    version="2.0.3",
     author="Xiaohui Wang, Ying Xiong, Xian Qian, Yang Wei",
     author_email="wangxiaohui.neo@bytedance.com, xiongying.taka@bytedance.com"
     ", qian.xian@bytedance.com, weiyang.god@bytedance.com",
@@ -110,13 +110,8 @@ setup_kwargs = dict(
     python_requires=">=3.6",
     cmdclass=dict(build_ext=CMakeBuild),
     zip_safe=False,
-    packages=setuptools.find_packages(exclude=["docs", "tests"]),
-    package_data={
-        "lightseq.training": [
-            path.replace("lightseq/training/", "")
-            for path in glob.glob("lightseq/training/csrc/**/*", recursive=True)
-        ],
-    },
+    packages=setuptools.find_packages(exclude=["docs", "tests"]) + ["."],
+    include_package_data=True,
     entry_points={
         "console_scripts": [
             "lightseq-train = examples.training.fairseq."


### PR DESCRIPTION
training compiles with cub in CUDA 11 and will cause a fatal error in CUDA 10, because it has not a build-in cub.

To fix it, using cub source code to compile in training jit