### PR TITLE
[WIP] fix overflow in GPT2

### DIFF
--- a/lightseq/inference/model/gpt_encoder.cc.cu
+++ b/lightseq/inference/model/gpt_encoder.cc.cu
@@ -156,7 +156,7 @@ void GptEncoder<OpType_>::run_one_infer(int batch_size, int batch_seq_len) {
 #endif
 
   for (_layer_id = 0; _layer_id < _tw._n_enc_layer; _layer_id++) {
-    _weight_offset = _layer_id * _tw._weight_per_enc_layer;
+    _weight_offset = (size_t)_layer_id * _tw._weight_per_enc_layer;
     self_attention();
     ffn_add_norm();
   }
@@ -211,7 +211,7 @@ int GptEncoder<OpType_>::run_one_sample(int batch_size, int batch_seq_len) {
 #endif
 
   for (_layer_id = 0; _layer_id < _tw._n_enc_layer; _layer_id++) {
-    _weight_offset = _layer_id * _tw._weight_per_enc_layer;
+    _weight_offset = (size_t)_layer_id * _tw._weight_per_enc_layer;
     self_attention(true);
     ffn_add_norm();
   }
@@ -245,7 +245,7 @@ int GptEncoder<OpType_>::run_one_sample(int batch_size, int batch_seq_len) {
               _batch_size * _tw._hidden_size);
 #endif
     for (_layer_id = 0; _layer_id < _tw._n_enc_layer; _layer_id++) {
-      _weight_offset = _layer_id * _tw._weight_per_enc_layer;
+      _weight_offset = (size_t)_layer_id * _tw._weight_per_enc_layer;
       self_attention_with_cache();
       ffn_add_norm_with_cache();
     }

--- a/lightseq/inference/model/gpt_encoder.h
+++ b/lightseq/inference/model/gpt_encoder.h
@@ -55,7 +55,7 @@ class GptEncoder {
   std::vector<int> _h_sample_id;
   int _h_unfinished;
 
-  // gpu memeory buffer
+  // gpu memory buffer
   _DataType *_p_d_query;
   _DataType *_p_d_k_cache;
   _DataType *_p_d_v_cache;
@@ -85,7 +85,7 @@ class GptEncoder {
   int _batch_size;
   int _batch_token_num;
   int _layer_id;
-  int _weight_offset;
+  size_t _weight_offset;
 
  public:
   int _batch_seq_len;

--- a/lightseq/inference/proto/gpt_weight.cc
+++ b/lightseq/inference/proto/gpt_weight.cc
@@ -69,9 +69,9 @@ Load the weights of embedding layer into GPU memory.
 template <OperationType OpType_>
 std::string GptWeight<OpType_>::proto_parse_emb_wei(
     const GptEmbeddingLayer &layer) {
-  std::vector<int> offset;
+  std::vector<size_t> offset;
   std::vector<float> value;
-  int idx = 0;
+  size_t idx = 0;
 
   offset.push_back(idx);
   if (layer.token_embedding_size() != _src_vocab_size * _hidden_size)
@@ -98,7 +98,7 @@ std::string GptWeight<OpType_>::proto_parse_emb_wei(
   std::vector<_DataType> raw_value;
   for (float e : value) raw_value.push_back(float2required(e));
   _d_src_emb_wei = raw_value;
-  for (int e : offset)
+  for (size_t e : offset)
     _p_d_src_emb_wei.push_back(thrust::raw_pointer_cast(_d_src_emb_wei.data()) +
                                e);
 
@@ -111,9 +111,9 @@ Load the weights of encoder into GPU memory.
 */
 template <OperationType OpType_>
 std::string GptWeight<OpType_>::proto_parse_enc_wei(const Gpt &gpt) {
-  std::vector<int> offset;
+  std::vector<size_t> offset;
   std::vector<float> value;
-  int idx = 0;
+  size_t idx = 0;
 
   for (auto enc_layer : gpt.encoder_stack()) {
     offset.push_back(idx);
@@ -200,7 +200,7 @@ std::string GptWeight<OpType_>::proto_parse_enc_wei(const Gpt &gpt) {
   for (float e : value) raw_value.push_back(float2required(e));
   _d_enc_wei = raw_value;
 
-  for (int e : offset)
+  for (size_t e : offset)
     _p_d_enc_wei.push_back(thrust::raw_pointer_cast(_d_enc_wei.data()) + e);
   std::cout << "finish initializing enc_wei from host to device" << std::endl;
   return "";
@@ -280,14 +280,14 @@ Load the weights of embedding layer into GPU memory.
 template <OperationType OpType_>
 void GptWeight<OpType_>::hdf5_parse_emb_wei(hid_t hdf5_file) {
   std::string dataset_prefix = "src_embedding";
-  size_t value_size = _src_vocab_size * _hidden_size +
+  size_t value_size = (size_t)_src_vocab_size * _hidden_size +
                       _max_step * _hidden_size + _hidden_size * 2;
 
-  std::vector<int> offset;
+  std::vector<size_t> offset;
   std::vector<float> value(value_size);  // preallocate vector for performance
   std::cout << "loading " << value_size * sizeof(OpType_) / (1024 * 1024)
             << " MB of embedding weight." << std::endl;
-  int idx = 0;
+  size_t idx = 0;
 
   offset.push_back(idx);
   read_hdf5_dataset_data(
@@ -323,7 +323,7 @@ void GptWeight<OpType_>::hdf5_parse_emb_wei(hid_t hdf5_file) {
   raw_value.reserve(value.size());
   for (float e : value) raw_value.push_back(float2required(e));
   _d_src_emb_wei = raw_value;
-  for (int e : offset)
+  for (size_t e : offset)
     _p_d_src_emb_wei.push_back(thrust::raw_pointer_cast(_d_src_emb_wei.data()) +
                                e);
 
@@ -341,7 +341,7 @@ void GptWeight<OpType_>::hdf5_parse_enc_wei(hid_t hdf5_file) {
        _hidden_size * _inner_size + _inner_size + _hidden_size * _inner_size +
        _hidden_size) *
       _n_enc_layer;
-  std::vector<int> offset;
+  std::vector<size_t> offset;
   std::vector<float> value(value_size);
   std::cout << "loading " << value_size * sizeof(OpType_) / (1024 * 1024)
             << " MB of encoder weight." << std::endl;
@@ -446,7 +446,7 @@ void GptWeight<OpType_>::hdf5_parse_enc_wei(hid_t hdf5_file) {
   for (float e : value) raw_value.push_back(float2required(e));
   _d_enc_wei = raw_value;
 
-  for (int e : offset)
+  for (size_t e : offset)
     _p_d_enc_wei.push_back(thrust::raw_pointer_cast(_d_enc_wei.data()) + e);
   std::cout << "finish initializing enc_wei from host to device" << std::endl;
 }

--- a/lightseq/inference/proto/gpt_weight.cc
+++ b/lightseq/inference/proto/gpt_weight.cc
@@ -336,7 +336,7 @@ Load the weights of encoder into GPU memory.
 template <OperationType OpType_>
 void GptWeight<OpType_>::hdf5_parse_enc_wei(hid_t hdf5_file) {
   size_t value_size =
-      (_hidden_size * 2 + _hidden_size * _hidden_size * 3 + _hidden_size * 3 +
+      ((size_t)_hidden_size * 2 + _hidden_size * _hidden_size * 3 + _hidden_size * 3 +
        _hidden_size * _hidden_size + _hidden_size * 3 +
        _hidden_size * _inner_size + _inner_size + _hidden_size * _inner_size +
        _hidden_size) *
@@ -346,8 +346,8 @@ void GptWeight<OpType_>::hdf5_parse_enc_wei(hid_t hdf5_file) {
   std::cout << "loading " << value_size * sizeof(OpType_) / (1024 * 1024)
             << " MB of encoder weight." << std::endl;
 
-  int idx = 0;
-  for (int layer_id = 0; layer_id < _n_enc_layer; ++layer_id) {
+  size_t idx = 0;
+  for (size_t layer_id = 0; layer_id < _n_enc_layer; ++layer_id) {
     std::string dataset_prefix = "encoder_stack/" + std::to_string(layer_id);
 
     offset.push_back(idx);


### PR DESCRIPTION
Due to the use of signed int in indices, model weights that exceed 4G can easily overflow. This PR is to fix them in GPT model inference.