### PR TITLE
pass activation_fn to LSFSTransformer encoder and decoder layer config

### DIFF
--- a/examples/training/fairseq/fs_modules/ls_transformer.py
+++ b/examples/training/fairseq/fs_modules/ls_transformer.py
@@ -202,6 +202,7 @@ class LSTransformerEncoder(FairseqEncoder):
             pre_layer_norm=args.encoder_normalize_before,
             fp16=args.fp16,
             local_rank=args.device_id,
+            activation_fn=args.activation_fn,
         )
         return LSTransformerEncoderLayer(config)
 
@@ -297,6 +298,7 @@ class LSTransformerDecoder(FairseqIncrementalDecoder):
             fp16=args.fp16,
             local_rank=args.device_id,
             nlayer=args.decoder_layers,
+            activation_fn=args.activation_fn,
         )
         return LSFSTransformerDecoderLayer(config)
 


### PR DESCRIPTION
It seems that the current fairseq plugin doesn't pass the `activation_fn` argument to `LSFSTransformerEncoderLayer.get_config` and `LSFSTransformerDecoderLayer.get_config`. So the activation function is always ReLU while training with fairseq. This commit fixed that, and the GeLU function can be used. 