### PR TITLE
Doc: fix the wrong version demand in the build.md

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -1,7 +1,7 @@
 # Build from source code
 
 ## Requirements
-- cudatoolkit-dev >= 10.1 < 11
+- cudatoolkit-dev >= 11, < 12
 - protobuf >= 3.13
 - cmake >= 3.18
 


### PR DESCRIPTION
The part in CMakeLists.txt seems:

```
find_package(CUDA 11 REQUIRED)
```